### PR TITLE
Initialize .gitignore for React/TypeScript/Vite project - Issue #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,123 @@
+# Dependencies
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+# Build outputs
+dist/
+build/
+out/
+.next/
+.nuxt/
+.vite/
+vite.config.js.timestamp-*
+vite.config.ts.timestamp-*
+
+# TypeScript
+*.tsbuildinfo
+.tsbuildinfo
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+.local
+
+# IDE and Editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.project
+.classpath
+.settings/
+*.sublime-project
+*.sublime-workspace
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+Desktop.ini
+
+# Logs
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+# Runtime data
+pids/
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage/
+*.lcov
+.nyc_output/
+
+# Temporary folders
+.tmp/
+.temp/
+.cache/
+
+# Optional npm cache directory
+.npm
+
+# Optional eslint cache
+.eslintcache
+
+# Optional stylelint cache
+.stylelintcache
+
+# Microbundle cache
+.rpt2_cache/
+.rts2_cache_cjs/
+.rts2_cache_es/
+.rts2_cache_umd/
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+
+# parcel-bundler cache (https://parceljs.org/)
+.parcel-cache/
+
+# Storybook build outputs
+.out
+.storybook-out
+storybook-static/
+
+# Vite
+.vite/
+vite.config.*.timestamp-*
+
+# Rollup
+.rollup.cache/
+
+# SvelteKit
+.svelte-kit/
+
+# Playwright
+test-results/
+playwright-report/
+playwright/.cache/


### PR DESCRIPTION
# Initialize .gitignore for React/TypeScript/Vite project - Issue #1

## Summary
Added a comprehensive `.gitignore` file with 123 patterns to exclude common files and directories for React/TypeScript/Vite projects. The file covers dependencies, build outputs, environment variables, IDE files, OS-generated files, logs, cache directories, and tool-specific outputs.

Resolves #1

## Review & Testing Checklist for Human
- [ ] **Verify framework-specific patterns are needed** - The .gitignore includes patterns for Next.js, Nuxt, SvelteKit, and other frameworks that may not be relevant to this specific project
- [ ] **Test with actual project files** - Once you add React/TypeScript/Vite project files, verify the .gitignore properly excludes node_modules, dist/, .env files, etc., and doesn't accidentally ignore legitimate project files
- [ ] **Check for overly broad patterns** - Review patterns like `*.log`, `.cache/`, `.tmp/` to ensure they won't exclude files you actually want to track

### Notes
- The repository is currently empty except for README.md, so the .gitignore effectiveness cannot be fully tested until actual project files are added
- The patterns are comprehensive and follow industry standards, but may include more than necessary for this specific project
- Link to Devin run: https://app.devin.ai/sessions/2419b0f21f9b459d99cf058853dfafd6
- Requested by: @ntua-el19128 (manos)