### PR TITLE
Add MIT license file - resolves issue #2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 ntua-el19128
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
# Add MIT license file - resolves issue #2

## Summary
Added a standard MIT license file to the repository root directory with copyright attribution to ntua-el19128. This addresses issue #2 which requested setting up a license file for the project.

## Review & Testing Checklist for Human
- [ ] Verify the copyright year (2025) is appropriate for this project
- [ ] Confirm the copyright holder "ntua-el19128" matches the intended attribution
- [ ] Check that the MIT license text follows the standard template and is complete

### Notes
This is a straightforward addition of a standard MIT license file. The license provides clear usage permissions for the codebase while maintaining appropriate copyright attribution.

Link to Devin run: https://app.devin.ai/sessions/51c0ee789a9c45329da52f564095cdf5

Requested by: manos (ntua-el19128)