### PR TITLE
Initialize .gitignore for issue #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,70 @@
+# Node.js dependencies and logs
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# Vite and build outputs
+dist/
+build/
+.vite/
+coverage/
+.nyc_output/
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Environment variables and configuration
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Logs
+*.log
+logs/
+
+# Cache directories
+.cache/
+.parcel-cache/
+.eslintcache
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Optional npm cache directory
+.npm
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+
+# dotenv environment variables file
+.env.test
+
+# Temporary folders
+tmp/
+temp/


### PR DESCRIPTION
# Initialize .gitignore for issue #1

## Summary
This PR adds a comprehensive `.gitignore` file to the repository as requested in issue #1. The file includes standard exclusion patterns for Node.js projects, Vite build tools, common IDEs, operating systems, and environment files.

The .gitignore file covers:
- **Node.js dependencies and logs**: `node_modules/`, npm/yarn/pnpm debug logs
- **Vite and build outputs**: `dist/`, `build/`, `.vite/`, coverage reports
- **IDE and environment files**: `.vscode/`, `.idea/`, `.env*` files, various log files
- **OS-generated files**: `.DS_Store`, `Thumbs.db`, and other system files

## Review & Testing Checklist for Human
- [ ] Verify that all patterns align with the project's specific needs and don't exclude any files that should be tracked
- [ ] Check if the `*.log` pattern is too broad for this project (might exclude important log files that should be version controlled)
- [ ] Confirm this implementation matches the requirements specified in issue #1

### Notes
- This is a straightforward file addition with no functional code changes, so manual verification of patterns is the primary testing method
- All patterns follow standard conventions for Node.js/React/Vite projects
- Link to Devin run: https://app.devin.ai/sessions/5a78a6c994774d8eb5288b70a25138be
- Requested by: @ntua-el19128 (manos)