### PR TITLE
Initialize .gitignore for React/TypeScript/Vite project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,89 @@
+# Dependencies
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+# Build outputs
+dist/
+build/
+.vite/
+.next/
+out/
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Testing
+coverage/
+.nyc_output/
+.jest/
+
+# IDE and Editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Logs
+*.log
+logs/
+
+# Runtime data
+pids/
+*.pid
+*.seed
+*.pid.lock
+
+# Temporary folders
+.tmp/
+.cache/
+.parcel-cache/
+
+# Optional npm cache directory
+.npm
+
+# Optional eslint cache
+.eslintcache
+
+# Microbundle cache
+.rpt2_cache/
+.rts2_cache_cjs/
+.rts2_cache_es/
+.rts2_cache_umd/
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+
+# dotenv environment variables file
+.env.test
+
+# Storybook build outputs
+storybook-static/
+
+# Vite
+.vite/
+vite.config.js.timestamp-*
+vite.config.ts.timestamp-*


### PR DESCRIPTION
# Initialize .gitignore for React/TypeScript/Vite project

## Summary
Added a comprehensive `.gitignore` file with 89 patterns covering standard exclusions for a React/TypeScript/Vite project. The file includes patterns for dependencies (`node_modules/`), build outputs (`dist/`, `.vite/`), environment files (`.env*`), IDE files (`.vscode/`, `.idea/`), OS-specific files (`.DS_Store`, `Thumbs.db`), and various development artifacts.

Resolves #1.

## Review & Testing Checklist for Human
- [ ] **Verify project type alignment** - Confirm this .gitignore matches the actual intended project structure (React/TypeScript/Vite)
- [ ] **Test with actual project files** - When project files are added, verify that essential configuration files (package.json, tsconfig.json, etc.) are still tracked
- [ ] **Check pattern effectiveness** - Add some test files/folders (like `node_modules/`, `dist/`, `.env`) to verify they're properly ignored by git status

### Notes
- Repository is currently empty except for README.md, so .gitignore patterns couldn't be tested against real project files
- Patterns are comprehensive and follow industry standards for React/TypeScript/Vite projects
- Some patterns may be more extensive than needed for this specific project

---
**Link to Devin run:** https://app.devin.ai/sessions/1ebace3a628e474f889248b685927eba  
**Requested by:** manos (@ntua-el19128)