### PR TITLE
1-initialize-gitignore: Add comprehensive .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,167 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+# Dependency directories
+node_modules/
+jspm_packages/
+
+# Package lock files
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage/
+*.lcov
+
+# nyc test coverage
+.nyc_output
+
+# Grunt intermediate storage (https://gruntjs.com/creating-plugins#storing-task-files)
+.grunt
+
+# Bower dependency directory (https://bower.io/)
+bower_components
+
+# node-waf configuration
+.lock-wscript
+
+# Compiled binary addons (https://nodejs.org/api/addons.html)
+build/Release
+
+# Dependency directories
+node_modules/
+jspm_packages/
+
+# TypeScript cache
+*.tsbuildinfo
+
+# Optional npm cache directory
+.npm
+
+# Optional eslint cache
+.eslintcache
+
+# Optional stylelint cache
+.stylelintcache
+
+# Microbundle cache
+.rpt2_cache/
+.rts2_cache_cjs/
+.rts2_cache_es/
+.rts2_cache_umd/
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+
+# dotenv environment variable files
+.env
+.env.development.local
+.env.test.local
+.env.production.local
+.env.local
+
+# parcel-bundler cache (https://parceljs.org/)
+.cache
+.parcel-cache
+
+# Next.js build output
+.next
+out
+
+# Nuxt.js build / generate output
+.nuxt
+dist
+
+# Gatsby files
+.cache/
+public
+
+# Vite build output
+dist/
+dist-ssr/
+*.local
+
+# Rollup.js default build output
+dist/
+
+# Webpack build output
+build/
+
+# Snowpack dependency directory (https://snowpack.dev/)
+web_modules/
+
+# Storybook build outputs
+.out
+.storybook-out
+storybook-static
+
+# Temporary folders
+tmp/
+temp/
+
+# Editor directories and files
+.vscode/
+!.vscode/extensions.json
+.idea/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Windows image file caches
+Thumbs.db
+ehthumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# Linux
+*~
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*


### PR DESCRIPTION
# 1-initialize-gitignore: Add comprehensive .gitignore file

## Summary
Adds a comprehensive `.gitignore` file to the repository covering Node.js/npm patterns, Vite-specific build outputs, and common IDE/OS files. This addresses Issue #1 by implementing proper version control exclusions for the project.

The `.gitignore` includes:
- **Node.js/npm patterns**: `node_modules/`, package lock files, logs, cache directories
- **Vite-specific exclusions**: `dist/`, `dist-ssr/`, `*.local` files
- **IDE/OS patterns**: `.vscode/`, `.idea/`, `.DS_Store`, editor temp files, Windows/Linux system files

## Review & Testing Checklist for Human
- [ ] Verify the ignore patterns align with the project's current and planned tech stack
- [ ] Check that no important project files (like custom config files) would be accidentally ignored
- [ ] Confirm the patterns match your team's development workflow preferences

### Notes
- This is a standard comprehensive .gitignore covering most common Node.js/frontend development scenarios
- Some patterns appear multiple times in the file (e.g., `node_modules/`, `dist`) but this doesn't affect functionality
- The `.vscode/` directory is ignored but `.vscode/extensions.json` is explicitly included, which is a common pattern for sharing VS Code extension recommendations

**Link to Devin run**: https://app.devin.ai/sessions/8a632d7f52f944a09d93eed031414478  
**Requested by**: @ntua-el19128 (manos)